### PR TITLE
fix(build): monkey & web

### DIFF
--- a/apps/monkey/src/Ctrl.vue
+++ b/apps/monkey/src/Ctrl.vue
@@ -34,7 +34,16 @@ async function start() {
     isFetchAll: configStore.state.isFetchAll,
     setTotal: total => postStore.total = total,
     addPosts: postStore.add,
-    stopCondition: () => postStore.fetchedPage >= postStore.pages,
+    stopCondition: () => {
+      const finished = postStore.fetchedPage >= postStore.pages
+
+      if (finished) {
+        isStart.value = false
+        isFinish.value = true
+        exportData(postStore.posts)
+      }
+      return finished
+    },
   })
   pauseFetch = pause
   resumeFetch = resume
@@ -45,15 +54,6 @@ watchEffect(() => {
     pauseFetch()
   else
     resumeFetch()
-
-  if (!isFinish.value)
-    return
-
-  if (postStore.fetchedPage >= postStore.pages) {
-    isStart.value = false
-    isFinish.value = true
-    exportData(postStore.posts)
-  }
 })
 
 // @ts-expect-error TODO: fix this

--- a/apps/monkey/src/stores/configStore.ts
+++ b/apps/monkey/src/stores/configStore.ts
@@ -3,19 +3,23 @@ import type { FetchOptions } from '@types'
 
 export const useConfigStore = defineStore('config', () => {
   const now = Date.now()
+  const localData = localStorage.getItem('fetchOptions')
 
-  const state = reactive<FetchOptions>({
-    uid: '',
-    name: '',
-    cookie: '',
-    isFetchAll: true,
-    picLarge: true,
-    repostPic: true,
-    repost: true,
-    comment: true,
-    commentCount: 10,
-    dateRange: [now, now],
-  })
+  const state = reactive<FetchOptions>(localData
+    ? JSON.parse(localData)
+    : {
+        uid: '',
+        name: '',
+        cookie: document.cookie,
+        isFetchAll: true,
+        picLarge: true,
+        repostPic: true,
+        repost: true,
+        comment: true,
+        commentCount: 10,
+        dateRange: [now, now],
+      },
+  )
 
   const setConfig = (config: Partial<FetchOptions>) => {
     Object.assign(state, config)

--- a/packages/core/src/services/postService.ts
+++ b/packages/core/src/services/postService.ts
@@ -11,8 +11,6 @@ import {
   weiFetch,
 } from '../utils'
 
-const options = (async () => await getOptions())()
-
 /**
  * 鉴权字段，必须得登录才获取得了，不然匿名只能获取前两页 <br/>
  * 并且只能往前，同一个 id 对于即便不同 page 的结果也是一样的
@@ -25,7 +23,7 @@ export async function fetchAllPosts(page = 1): FetchReturn {
   else if (page === 1)
     since_id = ''
 
-  const { uid } = options
+  const { uid } = await getOptions()
 
   const { data } = await weiFetch<{ data: PostMeta }>(`/statuses/mymblog?uid=${uid}&feature=0&page=${page}&since_id=${since_id}`)
 
@@ -41,7 +39,7 @@ export async function fetchAllPosts(page = 1): FetchReturn {
 }
 
 export async function fetchRangePosts(page = 1): FetchReturn {
-  const { uid, dateRange } = options
+  const { uid, dateRange } = await getOptions()
   const [start, end] = dateRange
 
   const { data } = await weiFetch<{ data: PostMeta }>(`/statuses/searchProfile?uid=${uid}&page=${page}&starttime=${start / 1000}&endtime=${end / 1000}&hasori=1&hasret=1&hastext=1&haspic=1&hasvideo=1&hasmusic=1`)
@@ -71,7 +69,7 @@ export async function fetchLongText(
  * 获取前 3 条评论 并集于 博主的评论
  */
 export async function fetchComments(post: Post): Promise<Comment[]> {
-  const { commentCount, comment } = options
+  const { commentCount, comment } = await getOptions()
 
   if (!post.user || post.comments_count === 0 || !comment)
     return []

--- a/packages/core/src/services/postService.ts
+++ b/packages/core/src/services/postService.ts
@@ -11,7 +11,7 @@ import {
   weiFetch,
 } from '../utils'
 
-const options = await getOptions()
+const options = (async () => await getOptions())()
 
 /**
  * 鉴权字段，必须得登录才获取得了，不然匿名只能获取前两页 <br/>

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -30,7 +30,7 @@ export async function userInfo(
 ): Promise<{ uid: string, name: string }> {
   const { data } = await weiFetch('/profile/info', {
     params: {
-      id: id ?? '',
+      uid: id ?? '',
       screen_name: name ?? '',
     },
   })

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -20,6 +20,7 @@ export async function getOptions() {
   if (typeof localStorage !== 'undefined') {
     return JSON.parse(localStorage.getItem('fetchOptions') || '{}') as FetchOptions
   }
+  // TODO: 在构建 monkey, web 时，注释下面几行
   else {
     const { config } = await import('./config')
     return config.store.fetchOptions

--- a/packages/core/src/utils/parse.ts
+++ b/packages/core/src/utils/parse.ts
@@ -129,13 +129,14 @@ export async function postFilter(
   if (!post || !post.id || (!options.repost && !!post.retweeted_status?.id))
     return undefined
 
-  const repostImg = !isRepost || (isRepost && options.repostPic)
+  const includeImgs = !isRepost || (isRepost && options.repostPic)
+  const imgSize = options.picLarge ? 'largest' : 'large'
 
   try {
     const res: Post = {
       id: post.id,
       text: await fetchLongText(post),
-      imgs: repostImg ? parseImg(post.pic_ids, post.pic_infos) : [],
+      imgs: includeImgs ? parseImg(imgSize, post.pic_ids, post.pic_infos) : [],
       reposts_count: post.reposts_count,
       comments_count: post.comments_count,
       like_count: post.attitudes_count,

--- a/packages/ui/src/MainImage.vue
+++ b/packages/ui/src/MainImage.vue
@@ -14,8 +14,9 @@ const props = withDefaults(defineProps<{
 })
 
 const realSrc = ref(props.src)
-const inElectron = computed(() => import.meta.env.PROD && (isElectron || !props.src.startsWith('/')))
+const inElectron = computed(() => import.meta.env.PROD && isElectron && !props.src.startsWith('/'))
 
+// TODO: build:web 的时候注释下面这段
 onBeforeMount(async () => {
   if (!inElectron.value)
     return

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,33 +155,6 @@ importers:
         specifier: ^7.0.15
         version: 7.0.15(vite@5.1.4)(vue@3.4.19)
 
-  apps/desktop/dist/win-unpacked/resources/app:
-    dependencies:
-      '@weibo-archiver/core':
-        specifier: workspace:*
-        version: link:../../../../../../packages/core
-      '@weibo-archiver/database':
-        specifier: workspace:*
-        version: link:../../../../../../packages/database
-      '@weibo-archiver/ui':
-        specifier: workspace:*
-        version: link:../../../../../../packages/ui
-      custom-electron-titlebar:
-        specifier: ^4.2.8
-        version: 4.2.8(electron@28.2.4)
-      electron-log:
-        specifier: ^5.1.1
-        version: 5.1.1
-      electron-updater:
-        specifier: 6.1.7
-        version: 6.1.7
-      fs-extra:
-        specifier: ^11.2.0
-        version: 11.2.0
-      vue-router:
-        specifier: ^4.3.0
-        version: 4.3.0(vue@3.4.19)
-
   apps/monkey:
     dependencies:
       '@weibo-archiver/ui':


### PR DESCRIPTION
虽然目前只能通过手动注释掉 node 相关的代码来保证顺利 build（因为 vite 没法直接 tree-shaked 掉动态导入的依赖）

同时修改了解析图片和导出数据的时机