### PR TITLE
fix(web): show followings remark and support remark search

### DIFF
--- a/apps/web-v2/src/components/followings/dataColumns.tsx
+++ b/apps/web-v2/src/components/followings/dataColumns.tsx
@@ -37,15 +37,31 @@ export const columns: ColumnDef<Following>[] = [
         title: '用户名',
       })
     },
+    filterFn: (row, _columnId, filterValue) => {
+      const keyword = String(filterValue ?? '').trim().toLowerCase()
+      if (!keyword)
+        return true
+
+      const name = String(row.original.name ?? '').trim().toLowerCase()
+      const remark = String(row.original.remark ?? '').trim().toLowerCase()
+
+      return name.includes(keyword) || remark.includes(keyword)
+    },
     cell: ({ row }) => {
       const uid = row.original.uid
+      const remark = row.original.remark?.trim()
       return (
         <a
           href={`https://weibo.com/u/${uid}`}
           target="_blank"
           class="hover:text-primary"
         >
-          {row.getValue('name')}
+          <div class="flex flex-col gap-1">
+            <span>{row.getValue('name')}</span>
+            {remark
+              ? <span class="text-xs text-muted-foreground">{remark}</span>
+              : null}
+          </div>
         </a>
       )
     },


### PR DESCRIPTION
## Summary
- show `remark` below the following name in the followings table
- support matching both `name` and `remark` in followings search
- keep the change scoped to the followings column definition

## Test plan
- [x] run `pnpm exec eslint apps/web-v2/src/components/followings/dataColumns.tsx`
- [x] open the followings page and verify `remark` is displayed under the name
- [x] search by following name and verify existing behavior still works
- [x] search by `remark` and verify the matching row is returned